### PR TITLE
JetStore Loader Fixes

### DIFF
--- a/cdk/jetstore_one/lambdas/status_update/main.go
+++ b/cdk/jetstore_one/lambdas/status_update/main.go
@@ -7,9 +7,8 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/artisoft-io/jetstore/jets/status_update/delegate"
-
 	// "github.com/aws/aws-lambda-go/events"
+	"github.com/artisoft-io/jetstore/jets/datatable"
 	"github.com/aws/aws-lambda-go/lambda"
 	"go.uber.org/zap"
 )
@@ -77,7 +76,7 @@ func main() {
 
 func handler(ctx context.Context, arguments map[string]interface{}) (err error) {
 	logger.Info("Starting in ", zap.String("AWS Region", c.AWSRegion))
-	ca := delegate.CommandArguments{
+	ca := datatable.StatusUpdate{
 		Status: arguments["-status"].(string),
 	}
 	v, err := strconv.Atoi(arguments["-peKey"].(string))

--- a/jets/apiserver/api_users.go
+++ b/jets/apiserver/api_users.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -72,6 +73,7 @@ func (server *Server) Login(w http.ResponseWriter, r *http.Request) {
 		"capabilities": jetsUser.GetCapabilities(),
 		"token": jetsUser.Token,
 		"gitProfile": jetsUser.UserGitProfile,
+		"jetstore_version": os.Getenv("JETS_VERSION"),
 	}
 	JSON(w, http.StatusOK, data)
 }

--- a/jets/datatable/status_update.go
+++ b/jets/datatable/status_update.go
@@ -155,12 +155,14 @@ func (ca *StatusUpdate) CoordinateWork() error {
 
 	case getStatusCount(ca.Dbpool, ca.PeKey, "failed") > 0:
 		ca.Status = "recovered"
-		err = updateStatus(ca.Dbpool, ca.PeKey, "failed", &ca.FailureDetails)
+		err = updateStatus(ca.Dbpool, ca.PeKey, "recovered", &ca.FailureDetails)
 
 	case getStatusCount(ca.Dbpool, ca.PeKey, "errors") > 0:
+		ca.Status = "errors"
 		err = updateStatus(ca.Dbpool, ca.PeKey, "errors", nil)
 
 	default:
+		ca.Status = "completed"
 		err = updateStatus(ca.Dbpool, ca.PeKey, "completed", nil)
 	}
 	if err != nil {

--- a/jets/datatable/status_update.go
+++ b/jets/datatable/status_update.go
@@ -1,4 +1,4 @@
-package delegate
+package datatable
 
 import (
 	"context"
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/artisoft-io/jetstore/jets/awsi"
-	"github.com/artisoft-io/jetstore/jets/datatable"
 	"github.com/artisoft-io/jetstore/jets/schema"
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -23,12 +22,17 @@ import (
 // JETS_DSN_JSON_VALUE
 // JETS_s3_INPUT_PREFIX
 
-type CommandArguments struct {
+// Status Update command line arguments
+// When used as a delegate from apiserver Dbpool is non nil
+// and then the connection properties (AwsDsnSecret, DbPoolSize, UsingSshTunnel, AwsRegion)
+// are not needed.
+type StatusUpdate struct {
 	AwsDsnSecret string
 	DbPoolSize int
 	UsingSshTunnel bool
 	AwsRegion string
 	Dsn string
+	Dbpool *pgxpool.Pool
 	PeKey int
 	Status	string
 	FailureDetails string
@@ -75,7 +79,7 @@ func updateStatus(dbpool *pgxpool.Pool, pipelineExecutionKey int, status string,
 
 // Package Main Functions
 // --------------------------------------------------------------------------------------
-func (ca *CommandArguments) ValidateArguments() []string {
+func (ca *StatusUpdate) ValidateArguments() []string {
 	var errMsg []string
 	if ca.Status == "" {
 		errMsg = append(errMsg, "Status must be provided (-status).")
@@ -83,7 +87,7 @@ func (ca *CommandArguments) ValidateArguments() []string {
 	if ca.PeKey < 0 {
 		errMsg = append(errMsg, "Pipeline Execution Status key must be provided (-peKey).")
 	}
-	if ca.Dsn == "" && ca.AwsDsnSecret == "" {
+	if ca.Dsn == "" && ca.AwsDsnSecret == "" && ca.Dbpool == nil {
 		ca.Dsn = os.Getenv("JETS_DSN_URI_VALUE")
 		if ca.Dsn == "" {
 			var err error
@@ -123,48 +127,56 @@ func (ca *CommandArguments) ValidateArguments() []string {
 	return errMsg
 }
 
-func (ca *CommandArguments) CoordinateWork() error {
-	// open db connection
+func (ca *StatusUpdate) CoordinateWork() error {
+	// open db connection, if not already opened
 	var err error
-	if ca.AwsDsnSecret != "" {
-		// Get the dsn from the aws secret
-		ca.Dsn, err = awsi.GetDsnFromSecret(ca.AwsDsnSecret, ca.UsingSshTunnel, ca.DbPoolSize)
-		if err != nil {
-			return fmt.Errorf("while getting dsn from aws secret: %v", err)
+	if ca.Dbpool == nil {
+		if ca.AwsDsnSecret != "" {
+			// Get the dsn from the aws secret
+			ca.Dsn, err = awsi.GetDsnFromSecret(ca.AwsDsnSecret, ca.UsingSshTunnel, ca.DbPoolSize)
+			if err != nil {
+				return fmt.Errorf("while getting dsn from aws secret: %v", err)
+			}
 		}
+		ca.Dbpool, err = pgxpool.Connect(context.Background(), ca.Dsn)
+		if err != nil {
+			return fmt.Errorf("while opening db connection: %v", err)
+		}
+		defer func() {
+			ca.Dbpool.Close()
+			ca.Dbpool = nil
+		}()	
 	}
-	dbpool, err := pgxpool.Connect(context.Background(), ca.Dsn)
-	if err != nil {
-		return fmt.Errorf("while opening db connection: %v", err)
-	}
-	defer dbpool.Close()
 
 	// Update the pipeline_execution_status based on worst case status
 	switch {
 	case ca.Status == "failed":
-		err = updateStatus(dbpool, ca.PeKey, "failed", &ca.FailureDetails)
+		err = updateStatus(ca.Dbpool, ca.PeKey, "failed", &ca.FailureDetails)
 
-	case getStatusCount(dbpool, ca.PeKey, "failed") > 0:
-		err = updateStatus(dbpool, ca.PeKey, "failed", &ca.FailureDetails)
+	case getStatusCount(ca.Dbpool, ca.PeKey, "failed") > 0:
+		ca.Status = "recovered"
+		err = updateStatus(ca.Dbpool, ca.PeKey, "failed", &ca.FailureDetails)
 
-	case getStatusCount(dbpool, ca.PeKey, "errors") > 0:
-		err = updateStatus(dbpool, ca.PeKey, "errors", nil)
+	case getStatusCount(ca.Dbpool, ca.PeKey, "errors") > 0:
+		err = updateStatus(ca.Dbpool, ca.PeKey, "errors", nil)
 
 	default:
-		err = updateStatus(dbpool, ca.PeKey, "completed", nil)
+		err = updateStatus(ca.Dbpool, ca.PeKey, "completed", nil)
 	}
 	if err != nil {
 		return fmt.Errorf("while updating process execution status: %v", err)
 	}
 	// Register out tables
-	err = datatable.RegisterDomainTables(dbpool, ca.PeKey)
-	if err != nil {
-		return fmt.Errorf("while registrying out tables to input_registry: %v", err)
+	if ca.Status != "failed" {
+		err = RegisterDomainTables(ca.Dbpool, ca.PeKey)
+		if err != nil {
+			return fmt.Errorf("while registrying out tables to input_registry: %v", err)
+		}
 	}
 
 	// Lock the session
-	client, sessionId, sourcePeriodKey := getPeInfo(dbpool, ca.PeKey)
-	err = schema.RegisterSession(dbpool, "domain_table", client, sessionId, sourcePeriodKey)
+	client, sessionId, sourcePeriodKey := getPeInfo(ca.Dbpool, ca.PeKey)
+	err = schema.RegisterSession(ca.Dbpool, "domain_table", client, sessionId, sourcePeriodKey)
 	if err != nil {
 		log.Printf("Failed locking the session, must be already locked: %v (ignoring the error)", err)
 	}	

--- a/jets/loader/loader.go
+++ b/jets/loader/loader.go
@@ -268,10 +268,10 @@ func processFileAndReportStatus(dbpool *pgxpool.Pool,
 		"client":      *client,
 		"object_type": *objectType,
 	}
-	if status == "completed" {
-		awsi.LogMetric(*completedMetric, dimentions, 1)
-	} else {
+	if status == "failed" {
 		awsi.LogMetric(*failedMetric, dimentions, 1)
+	} else {
+		awsi.LogMetric(*completedMetric, dimentions, 1)
 	}
 
 	err = registerCurrentLoad(copy2DbResult.CopyCount, copy2DbResult.BadRowCount, dbpool, headersDKInfo, status, errMessage)

--- a/jets/loader/loader.go
+++ b/jets/loader/loader.go
@@ -249,7 +249,7 @@ func processFileAndReportStatus(dbpool *pgxpool.Pool,
 		}
 	}
 	// register the session if status is not failed
-	if status != "failed" && !*doNotLockSessionId {
+	if status != "failed" {
 
 		err = schema.RegisterSession(dbpool, "file", *client, *sessionId, *sourcePeriodKey)
 		if err != nil {

--- a/jets/loader/main.go
+++ b/jets/loader/main.go
@@ -47,7 +47,6 @@ var userEmail = flag.String("userEmail", "", "User identifier to register the lo
 var nbrShards = flag.Int("nbrShards", 1, "Number of shards to use in sharding the input file")
 var sourcePeriodKey = flag.Int("sourcePeriodKey", -1, "Source period key associated with the in_file (fileKey)")
 var sessionId = flag.String("sessionId", "", "Process session ID, is needed as -inSessionId for the server process (must be unique), default based on timestamp.")
-var doNotLockSessionId = flag.Bool("doNotLockSessionId", false, "Do NOT lock sessionId on sucessful completion (default is to lock the sessionId on successful completion")
 var completedMetric = flag.String("loaderCompletedMetric", "loaderCompleted", "Metric name to register the loader successfull completion (default: loaderCompleted)")
 var failedMetric = flag.String("loaderFailedMetric", "loaderFailed", "Metric name to register the load failure [success load metric: loaderCompleted] (default: loaderFailed)")
 var tableName string
@@ -196,7 +195,6 @@ func main() {
 	fmt.Println("Got argument: userEmail", *userEmail)
 	fmt.Println("Got argument: nbrShards", *nbrShards)
 	fmt.Println("Got argument: sessionId", *sessionId)
-	fmt.Println("Got argument: doNotLockSessionId", *doNotLockSessionId)
 	fmt.Println("Got argument: usingSshTunnel", *usingSshTunnel)
 	fmt.Println("Got argument: loaderCompletedMetric", *completedMetric)
 	fmt.Println("Got argument: loaderFailedMetric", *failedMetric)

--- a/jets/loader/register_load.go
+++ b/jets/loader/register_load.go
@@ -28,8 +28,8 @@ func registerCurrentLoad(copyCount int64, badRowCount int64, dbpool *pgxpool.Poo
 		return fmt.Errorf("error inserting in jetsapi.input_loader_status table: %v", err)
 	}
 	log.Println("Updated input_loader_status table with main object type:", *objectType, "client", *client, "org", *clientOrg)
-	// Register all loads, even when status != "completed" to provide visibility of the loaded data in UI
-	if dkInfo != nil {
+	// Register loads, except when status == "failed" or copyCount == 0
+	if dkInfo != nil && copyCount > 0 && status != "failed" {
 		inputRegistryKey = make([]int, len(dkInfo.DomainKeysInfoMap))
 		ipos := 0
 		for objType := range dkInfo.DomainKeysInfoMap {

--- a/jets/status_update/main.go
+++ b/jets/status_update/main.go
@@ -4,7 +4,8 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"github.com/artisoft-io/jetstore/jets/status_update/delegate"
+
+	"github.com/artisoft-io/jetstore/jets/datatable"
 )
 
 // Env variable:
@@ -29,7 +30,7 @@ func main() {
 	fmt.Println("CMD LINE ARGS:",os.Args[1:])
 	flag.Parse()
 
-	ca := &delegate.CommandArguments{
+	ca := &datatable.StatusUpdate{
 		AwsDsnSecret: *awsDsnSecret,
 		DbPoolSize: *dbPoolSize,
 		UsingSshTunnel: *usingSshTunnel,

--- a/jetsclient/lib/modules/actions/user_delegates.dart
+++ b/jetsclient/lib/modules/actions/user_delegates.dart
@@ -53,6 +53,9 @@ Future<String?> loginFormActions(BuildContext context,
 
       if (result.statusCode == 200) {
         // update the [UserModel]
+        var version = (result.body[FSK.jetstoreVersion] ?? '###') as String;
+        if(version.isEmpty) version = '###';
+        JetsRouterDelegate().jetstoreVersion = version;
         JetsRouterDelegate().user.name = result.body[FSK.userName];
         JetsRouterDelegate().user.email = result.body[FSK.userEmail];
         JetsRouterDelegate().user.isAdmin = result.body[FSK.isAdmin];

--- a/jetsclient/lib/routes/jets_router_delegate.dart
+++ b/jetsclient/lib/routes/jets_router_delegate.dart
@@ -17,8 +17,9 @@ class JetsRouterDelegate extends RouterDelegate<JetsRouteData>
   }
 
   final GlobalKey<NavigatorState> _navigatorKey;
-  JetsRouteData routeData = JetsRouteData(homePath);
+  JetsRouteData routeData = const JetsRouteData(homePath);
 
+  String jetstoreVersion = '###';
   var user = UserModel();
   var devMode = false;
   List<MaterialPage> _pages = [];

--- a/jetsclient/lib/screens/base_screen.dart
+++ b/jetsclient/lib/screens/base_screen.dart
@@ -11,6 +11,7 @@ import 'package:jetsclient/models/form_config.dart';
 import 'package:jetsclient/models/screen_config.dart';
 import 'package:split_view/split_view.dart';
 import 'package:flutter_simple_treeview/flutter_simple_treeview.dart';
+import 'package:intl/intl.dart';
 
 /// Signature for building the widget of main area of BaseScreen.
 typedef ScreenWidgetBuilder = Widget Function(
@@ -219,13 +220,12 @@ class BaseScreenState extends State<BaseScreen> with TickerProviderStateMixin {
                             child: menuEntry.label.isEmpty
                                 ? const SizedBox(
                                     height: defaultPadding,
-                                    width: 2*defaultPadding,
+                                    width: 2 * defaultPadding,
                                   )
                                 : TextButton(
                                     style: buttonStyle(
                                         getActionStyle(menuEntry), themeData),
-                                    onPressed: () => menuEntry.routePath !=
-                                            null
+                                    onPressed: () => menuEntry.routePath != null
                                         ? JetsRouterDelegate()(JetsRouteData(
                                             menuEntry.routePath!,
                                             params: menuEntry.routeParams))
@@ -302,7 +302,19 @@ class BaseScreenState extends State<BaseScreen> with TickerProviderStateMixin {
                                     0, context, themeData, menuEntry))
                                 .toList()),
                       ),
-                    )
+                    ),
+                    if (JetsRouterDelegate().jetstoreVersion != '###')
+                      Padding(
+                        padding: const EdgeInsets.fromLTRB(8.0, 8.0, 8.0, 0.0),
+                        child: Text(
+                            'Version ${JetsRouterDelegate().jetstoreVersion}'),
+                      ),
+                    if (JetsRouterDelegate().jetstoreVersion != '###')
+                      Padding(
+                        padding: const EdgeInsets.all(8.0),
+                        child: Text(
+                            'build on ${DateFormat.yMMMd().format(DateTime.fromMillisecondsSinceEpoch(int.parse(JetsRouterDelegate().jetstoreVersion), isUtc: true))}'),
+                      ),
                   ]),
                   // Client area
                   JetsSpinnerOverlay(child: widget.builder(context, this)),

--- a/jetsclient/lib/screens/base_screen.dart
+++ b/jetsclient/lib/screens/base_screen.dart
@@ -313,7 +313,7 @@ class BaseScreenState extends State<BaseScreen> with TickerProviderStateMixin {
                       Padding(
                         padding: const EdgeInsets.all(8.0),
                         child: Text(
-                            'build on ${DateFormat.yMMMd().format(DateTime.fromMillisecondsSinceEpoch(int.parse(JetsRouterDelegate().jetstoreVersion), isUtc: true))}'),
+                            'build on ${DateFormat.yMMMd().format(DateTime.fromMillisecondsSinceEpoch(int.parse(JetsRouterDelegate().jetstoreVersion) * 1000, isUtc: true))}'),
                       ),
                   ]),
                   // Client area

--- a/jetsclient/lib/utils/constants.dart
+++ b/jetsclient/lib/utils/constants.dart
@@ -284,6 +284,8 @@ class FSK {
   static const dataTableAction = "datatable.action";
   static const dataTableFromTable = "datatable.from.table";
 
+  static const jetstoreVersion = "jetstore_version";
+
   static const userEmail = "user_email";
   static const userName = "name";
   static const userRoles = "roles";

--- a/jetsclient/pubspec.lock
+++ b/jetsclient/pubspec.lock
@@ -352,6 +352,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
+  intl:
+    dependency: "direct main"
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   io:
     dependency: transitive
     description:

--- a/jetsclient/pubspec.yaml
+++ b/jetsclient/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   split_view: ^3.2.1
   flutter_simple_treeview: ^3.0.2
   flutter_typeahead: ^5.0.1
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:

--- a/utils/cdk_bootstrap.sh
+++ b/utils/cdk_bootstrap.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+cd ./cdk/bootstrap_aws
+echo "running cdk bootstrap"
+cdk bootstrap $CDK_BOOTSTRAP_ARG

--- a/utils/cdk_bootstrap.sh
+++ b/utils/cdk_bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-cd ./cdk/bootstrap_aws
+# cd ./cdk/bootstrap_aws
 echo "running cdk bootstrap"
 cdk bootstrap $CDK_BOOTSTRAP_ARG


### PR DESCRIPTION
Bug fixes:

- JetStore Fix: Do not register loaded data and auto start pipelines when it failed or when no data was loaded [#1125](https://github.com/artisoft-io/jetstore/issues/1125)
- When the loader failed, JetStore started the automated pipelines even though no data were loaded. This fix prevents the registration of failed loads and starting any automated pipelines.
- JetStore Fix: When dropping the staging table, remove all registered sessions from input_registry table [#1126](https://github.com/artisoft-io/jetstore/issues/1126)
- When a user drops the staging table, JetStore did not remove the registered loads associated with the staging table. As a result, a user may start a pipeline manually for a load that no longer exists and the error indicates that the staging table does not exist. The fix removes all registered loads associated with the staging table when the table is dropped.

Additional Improvements:

- JetStore Do not register server output table when server fails [#1129](https://github.com/artisoft-io/jetstore/issues/1129)
- Similarly to the loader, this is to prevent registering empty results when the mapping server fails.
- JetStore UI Add build version for display [#830](https://github.com/artisoft-io/jetstore/issues/830)
- The build version and build date is not visible on the ui.