### PR TITLE
USI: Fix brighton list of diagnosis in single field

### DIFF
--- a/jets/cleansing_functions/cleansing_functions.go
+++ b/jets/cleansing_functions/cleansing_functions.go
@@ -1,8 +1,12 @@
 package cleansing_functions
 
 import (
+	"bytes"
 	"database/sql"
+	"encoding/csv"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"math"
 	"regexp"
@@ -408,11 +412,225 @@ func (ctx *CleansingFunctionContext) ApplyCleasingFunction(functionName *string,
 			log.Panicf("ERROR missing argument for function split_on for input column pos %d", inputPos)
 		}
 
+	case "slice_input":
+		if inputValue == nil {
+			obj = nil
+		}	else {
+		if argument != nil {
+			obj = SliceInput(*inputValue, *argument, ctx.parsedFunctionArguments)
+		} else {
+			// configuration error, bailing out
+			log.Panicf("ERROR missing argument for function slice_input for input column pos %d", inputPos)
+		}
+		}
+
 	default:
 		log.Panicf("ERROR unknown mapping function: %s", *functionName)
 	}
 
 	return obj, errMsg
+}
+
+func SliceInput(inputValue, argument string, parsedFunctionArguments map[string]any) any {
+	if inputValue == "" {
+		return nil
+	}
+	sliceArg, err := ParseSliceInputFunctionArgument(argument, "slice_input", parsedFunctionArguments)
+	if err != nil {
+		log.Panicf("while parsing arguments for cleansing function parse_input: %v", err)
+	}
+	sliceValues := strings.Split(inputValue, sliceArg.Delimit)
+	l := len(sliceValues)
+	var values []string
+	switch {
+	case l == 0:
+		return nil
+	case sliceArg.From == nil && sliceArg.To == nil && sliceArg.Values == nil:
+		return sliceValues
+	case sliceArg.Values != nil:
+		values = make([]string, 0, len(*sliceArg.Values))
+		for _, i := range *sliceArg.Values {
+			if i < l {
+				values = append(values, sliceValues[i])
+			}
+		}
+	case sliceArg.From != nil && sliceArg.To == nil:
+		lenValues := l - *sliceArg.From
+		values = make([]string, 0, lenValues)
+		for i := range lenValues {
+			index := *sliceArg.From + i
+			if index < l {
+				values = append(values, sliceValues[index])
+			}
+		}
+	default:
+		lenValues := *sliceArg.To - *sliceArg.From
+		values = make([]string, 0, lenValues)
+		for i := range lenValues {
+			index := *sliceArg.From + i
+			if index < l {
+				values = append(values, sliceValues[index])
+			}
+		}
+	}
+	return values
+}
+
+type SliceInputFunctionArg struct {
+	Delimit string
+	Values  *[]int
+	From    *int
+	To      *int
+}
+
+func ParseSliceInputFunctionArgument(rawArg string, functionName string, cache map[string]any) (*SliceInputFunctionArg, error) {
+	// rawArg is csv-encoded as: "delimit","from",":","to"
+	// rawArg is csv-encoded as: "delimit","v1","v2","v3",...
+	// delimit is text
+	// Case "delimit","from",":","to":
+	//	- when: "delimit","from",":" then take all elements starting at `from` (encoded as nil for To).
+	//	- otherwise take input[from:to] (from is inclusive and to is exclusive)
+	// Case "delimit","v1","v2","v3",...
+	//	- when only delimit is provided, take all values (encoded as nil for values, from and to).
+	//	- when "v1","v2","v3",..., take only the specified element (0-based) (encoded as values, nil for from and to).
+	//	Note: when value is negative, it means len(input) - value (this applies to from and to as well)
+	if rawArg == "" {
+		return nil, fmt.Errorf("unexpected null argument to %s function", functionName)
+	}
+	// Check if we have it cached
+	key := fmt.Sprintf("%s(%s)", functionName, rawArg)
+	v := cache[key]
+	if v != nil {
+		fmt.Println("*** OK Got Cached value for", rawArg, ":", v)
+		return v.(*SliceInputFunctionArg), nil
+	}
+	// Parsed the raw argument into SliceInputFunctionArg and put it in the cache
+	rows, err := Parse(rawArg)
+	if len(rows) == 0 || len(rows[0]) == 0 || err != nil {
+		// It's not csv or config not valid
+		return nil, fmt.Errorf("error: no-data: argument '%s' cannot be parsed as csv or is invalid: %v (%s function)", rawArg, err, functionName)
+	}
+	var results *SliceInputFunctionArg
+	switch {
+	case len(rows[0]) == 1:
+		results = &SliceInputFunctionArg{
+			Delimit: rows[0][0],
+		}
+	case len(rows[0]) == 2:
+		v1, err := strconv.Atoi(strings.TrimSpace(rows[0][1]))
+		if err != nil {
+			return nil, fmt.Errorf("error: invalid argument '%s' expecting int value as second argument: %v (%s function)", rawArg, err, functionName)
+		}
+		results = &SliceInputFunctionArg{
+			Delimit: rows[0][0],
+			Values:  &[]int{v1},
+		}
+	case len(rows[0]) > 2 && rows[0][2] == ":":
+		from, err := strconv.Atoi(strings.TrimSpace(rows[0][1]))
+		if err != nil {
+			return nil, fmt.Errorf("error: invalid argument '%s' expecting from (int) as second argument: %v (%s function)", rawArg, err, functionName)
+		}
+		switch len(rows[0]) {
+		case 3:
+			results = &SliceInputFunctionArg{
+				Delimit: rows[0][0],
+				From:    &from,
+			}
+		case 4:
+			to, err := strconv.Atoi(strings.TrimSpace(rows[0][3]))
+			if err != nil {
+				return nil, fmt.Errorf("error: invalid argument '%s' expecting to (int) as forth argument: %v (%s function)", rawArg, err, functionName)
+			}
+			results = &SliceInputFunctionArg{
+				Delimit: rows[0][0],
+				From:    &from,
+				To:      &to,
+			}
+		default:
+			return nil, fmt.Errorf("error: invalid argument '%s' expecting \"from\",\":\",\"to\" construct (%s function)", rawArg, functionName)
+		}
+	default:
+		values := make([]int, 0, len(rows[0])-1)
+		for _, vstr := range rows[0][1:] {
+			v, err := strconv.Atoi(strings.TrimSpace(vstr))
+			if err != nil {
+				return nil, fmt.Errorf("error: invalid argument '%s' expecting int value as argument: %v (%s function)", rawArg, err, functionName)
+			}
+			values = append(values, v)
+		}
+		results = &SliceInputFunctionArg{
+			Delimit: rows[0][0],
+			Values:  &values,
+		}
+	}
+	cache[key] = results
+	return results, nil
+}
+type Chartype rune
+
+// Single character type for csv options
+func (s *Chartype) String() string {
+	return string(rune(*s))
+}
+
+func (s *Chartype) Set(value string) error {
+	r := []rune(value)
+	if len(r) > 1 || r[0] == '\n' {
+		return errors.New("sep must be a single char not '\\n'")
+	}
+	*s = Chartype(r[0])
+	return nil
+}
+
+func DetectDelimiter(buf []byte) (sep_flag Chartype, err error) {
+	// auto detect the separator based on the first line
+	nb := len(buf)
+	if nb > 2048 {
+		nb = 2048
+	}
+	txt := string(buf[0:nb])
+	cn := strings.Count(txt, ",")
+	pn := strings.Count(txt, "|")
+	tn := strings.Count(txt, "\t")
+	td := strings.Count(txt, "~")
+	switch {
+	case (cn > pn) && (cn > tn) && (cn > td):
+		sep_flag = ','
+	case (pn > cn) && (pn > tn) && (pn > td):
+		sep_flag = '|'
+	case (tn > cn) && (tn > pn) && (tn > td):
+		sep_flag = '\t'
+	case (td > cn) && (td > pn) && (td > tn):
+		sep_flag = '~'
+	default:
+		return 0, fmt.Errorf("error: cannot determine the csv-delimit used in buf")
+	}
+	return
+}
+
+// Parse the csvBuf, if cannot determine the separator, will assume it's a single column
+// and default to use the ','
+func Parse(csvBuf string) ([][]string, error) {
+	byteBuf := []byte(csvBuf)
+	sepFlag, err := DetectDelimiter(byteBuf)
+	if err != nil {
+		// Cannot detect delimiter, assume it's a single column
+		sepFlag = ','
+	}
+	r := csv.NewReader(bytes.NewReader(byteBuf))
+	r.Comma = rune(sepFlag)
+	results := make([][]string, 0)
+	for {
+		row, err := r.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("while parsing csv row: %v", err)
+		}
+		results = append(results, row)
+	}
+	return results, nil
 }
 
 func SplitOn(inputValue, argument *string) interface{} {

--- a/jets/serverv2/jets_init_db.sql
+++ b/jets/serverv2/jets_init_db.sql
@@ -19,6 +19,7 @@ INSERT INTO jetsapi.mapping_function_registry (function_name, is_argument_requir
   ('parse_amount',           '1'),
   ('reformat0',              '1'),
   ('scale_units',            '1'),
+  ('slice_input',            '1'),
   ('split_on',               '1'),
   ('to_upper',               '0'),
   ('to_zip5',                '0'),


### PR DESCRIPTION
Added 'slice_input' cleansing function to split the list of  diagnosis and be able to assign specific list element to various fields of the canonical model.